### PR TITLE
Fix: Resolve failing tests by correcting package.json and Jest config…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "@testing-library/react": "^12.1.2",
         "babel-jest": "^27.5.1",
         "jest": "^27.5.1",
+        "jest-environment-jsdom": "^27.5.1",
         "react-test-renderer": "^15.6.1"
       }
     },

--- a/package.json
+++ b/package.json
@@ -26,13 +26,13 @@
     "@testing-library/react": "^12.1.2",
     "babel-jest": "^27.5.1",
     "jest": "^27.5.1",
+    "jest-environment-jsdom": "^27.5.1",
     "react-test-renderer": "^15.6.1"
   },
   "jest": {
-    "testEnvironment": "jsdom"
-    "jest": "^27.5.1",
-    "babel-jest": "^27.5.1",
-    "react-test-renderer": "^15.6.1",
-    "@testing-library/react": "^12.1.2"
+    "testEnvironment": "jsdom",
+    "transform": {
+      "^.+\\.(js|jsx)$": "babel-jest"
+    }
   }
 }


### PR DESCRIPTION
…uration

The initial test execution failed due to several issues:
- A JSON parsing error in `package.json` (missing comma).
- Invalid options in the `jest` configuration within `package.json`.
- Missing `jest-environment-jsdom` dependency.
- Version mismatch between `jest-environment-jsdom` and `jest`.
- Missing `transform` configuration for `babel-jest`.

I addressed these issues by:
- Correcting the syntax in `package.json`.
- Removing invalid Jest options.
- Installing `jest-environment-jsdom`.
- Aligning the version of `jest-environment-jsdom` (v27.5.1) with the Jest version (v27.5.1).
- Adding a `transform` configuration to `package.json` to ensure `babel-jest` processes the files.

After these changes, all tests in `src/components/app.test.jsx` and `src/components/board.test.jsx` pass successfully.